### PR TITLE
fix: correct typo + add target to link

### DIFF
--- a/index.html
+++ b/index.html
@@ -111,7 +111,7 @@
                             les conserver.
                         </p>
                         <p>
-                            Un premier lien : <a href="https://drafts.csswg.org/indexes/"
+                            Un premier lien : <a href="https://drafts.csswg.org/indexes/" target="_blank"
                                 >l'index CSS du CSS working group du W3C</a
                             > qui liste toutes les propriétés, leurs valeurs, la grammaire utilisée pour appeler leur
                             valeur (moins utile), les fonctions, les règles @ et les sélecteurs du langage qui sont
@@ -889,7 +889,7 @@
                                 </p>
                                 <p>
                                     <strong>
-                                        Quelques exemples : <a href="https://codepen.io/c3dr0x/full/ExXMNRZ"
+                                        Quelques exemples : <a href="https://codepen.io/c3dr0x/full/ExXMNRZ" target="_blank"
                                             >https://codepen.io/c3dr0x/full/ExXMNRZ</a
                                         >
                                     </strong>
@@ -1491,7 +1491,7 @@
                     <section>
                         <h3>Présentation</h3>
                         <img src="img/box_model.png" alt="Box model" />
-                        <a href="https://codepen.io/c3dr0x/pen/oNwVYdG">https://codepen.io/c3dr0x/pen/oNwVYdG</a>
+                        <a href="https://codepen.io/c3dr0x/pen/oNwVYdG" target="_blank">https://codepen.io/c3dr0x/pen/oNwVYdG</a>
                     </section>
 
                     <section>
@@ -1612,7 +1612,7 @@
                             inset, groove, etc. : la liste peut-être consultée ici :
                         </p>
                         <p>
-                            <a href="https://developer.mozilla.org/fr/docs/Web/CSS/border-style"
+                            <a href="https://developer.mozilla.org/fr/docs/Web/CSS/border-style" target="_blank"
                                 >https://developer.mozilla.org/fr/docs/Web/CSS/border-style</a
                             >
                         </p>
@@ -1669,14 +1669,14 @@
                     <section>
                         <h3>Margin</h3>
                         <p>
-                            Petite démonstration interactive : <a href="https://codepen.io/klee-academy/full/GVWogL"
+                            Petite démonstration interactive : <a href="https://codepen.io/klee-academy/full/GVWogL" target="_blank"
                                 >https://codepen.io/klee-academy/full/GVWogL</a
                             >
                         </p>
                         <p>
                             Pour aller plus loin (facultatif, avancé) : voici une vidéo qui parle de margin collapsing
                             (et de float, que nous aborderons plus tard) et des conséquences imprévues : <a
-                                href="https://www.youtube.com/watch?v=Y5Xa4H2wtVA"
+                                href="https://www.youtube.com/watch?v=Y5Xa4H2wtVA" target="_blank"
                                 >https://www.youtube.com/watch?v=Y5Xa4H2wtVA</a
                             > (en anglais, il s'agit d'une vidéo de la BlinkOn, la conférence du moteur de rendu Blink
                             qui montre notamment le fonctionnement interne des marges dans le navigateur ).
@@ -1749,7 +1749,7 @@
                             position initiale.
                         </p>
                         <p>
-                            Dans l'exemple <a href="https://codepen.io/c3dr0x/pen/jOwJVGj"
+                            Dans l'exemple <a href="https://codepen.io/c3dr0x/pen/jOwJVGj" target="_blank"
                                 >https://codepen.io/c3dr0x/pen/jOwJVGj</a
                             >, les éléments 3 et 3-2 sont affichés relativement à leurs parents respectifs, à 30 pixels
                             du haut et de la gauche du parent.
@@ -1772,7 +1772,7 @@
                     <section>
                         <h3>Position : absolute</h3>
                         <p>
-                            Dans l'exemple <a href="https://codepen.io/c3dr0x/pen/dyRrOJV"
+                            Dans l'exemple <a href="https://codepen.io/c3dr0x/pen/dyRrOJV" target="_blank"
                                 >https://codepen.io/c3dr0x/pen/dyRrOJV</a
                             > :
                         </p>
@@ -1799,7 +1799,7 @@
                             sera placé à la position qu'il était supposé occuper dans le flux.
                         </p>
                         <p>
-                            Dans l'exemple <a href="https://codepen.io/c3dr0x/pen/NWgJbym"
+                            Dans l'exemple <a href="https://codepen.io/c3dr0x/pen/NWgJbym" target="_blank"
                                 >https://codepen.io/c3dr0x/pen/NWgJbym</a
                             >, l'élément 2 est affiché en position: fixed, en top:0px et left:50%. Si vous scrollez,
                             vous remarquerez qu'il conserve la même position.
@@ -1814,7 +1814,7 @@
                             accroché.
                         </p>
                         <p>
-                            Dans l'exemple <a href="https://codepen.io/c3dr0x/pen/RwgdoMy"
+                            Dans l'exemple <a href="https://codepen.io/c3dr0x/pen/RwgdoMy" target="_blank"
                                 >https://codepen.io/c3dr0x/pen/RwgdoMy</a
                             >, l'élément 2 est défini en position: sticky, avec top: 50px. L'élément est positionné à sa
                             position normale, cependant dès qu'on scrolle, si l'élément 2 arrive à 50 pixels du haut de
@@ -1838,10 +1838,10 @@
                             Les éléments en float d'un même côté s'empilent les uns à côté des autres. S'il n'y a pas la
                             place de s'empiler, l'élément se positionnera le plus haut possible tout en se collant sur
                             le côté souhaité. Ce comportement est visible ici : <a
-                                href="https://float-layout.glitch.me/"
+                                href="https://float-layout.glitch.me/" target="_blank"
                                 >https://float-layout.glitch.me/</a
                             > ou dans cette vidéo (d'un niveau avancé, en anglais) :
-                            <a href="https://youtu.be/Y5Xa4H2wtVA?t=1540">https://youtu.be/Y5Xa4H2wtVA?t=1540</a>
+                            <a href="https://youtu.be/Y5Xa4H2wtVA?t=1540" target="_blank">https://youtu.be/Y5Xa4H2wtVA?t=1540</a>
                         </p>
                     </section>
 
@@ -1877,7 +1877,7 @@
                         <p>Pour se positionner selon tous les éléments flottants, on utilise clear: both;.</p>
                         <p>
                             Exemple :
-                            <a href="https://codepen.io/c3dr0x/full/xxrBRQr">https://codepen.io/c3dr0x/full/xxrBRQr</a>
+                            <a href="https://codepen.io/c3dr0x/full/xxrBRQr" target="_blank">https://codepen.io/c3dr0x/full/xxrBRQr</a>
                         </p>
                     </section>
                 </section>
@@ -1932,7 +1932,7 @@
                             des display: block.
                         </p>
                         <p>
-                            Exemples : <a href="https://codepen.io/c3dr0x/pen/qBjvqvV"
+                            Exemples : <a href="https://codepen.io/c3dr0x/pen/qBjvqvV" target="_blank"
                                 >https://codepen.io/c3dr0x/pen/qBjvqvV</a
                             >
                         </p>
@@ -1983,7 +1983,7 @@
 
                     <section>
                         <h3>Exercice 3</h3>
-                        <p><a href="http://flexboxfroggy.com/">http://flexboxfroggy.com/</a></p>
+                        <p><a href="http://flexboxfroggy.com/" target="_blank">http://flexboxfroggy.com/</a></p>
                         <p>
                             Si vous désirez en savoir plus (car il existe d'autres propriétés), vous pourrez les trouver
                             détaillées ici : <a href="https://css-tricks.com/snippets/css/a-guide-to-flexbox/"
@@ -2001,7 +2001,7 @@
                         </p>
                         <p>
                             Flex est compatible avec tous les navigateurs, même IE 11! <a
-                                href="http://caniuse.com/#feat=flexbox"
+                                href="http://caniuse.com/#feat=flexbox" target="_blank"
                                 >http://caniuse.com/#feat=flexbox</a
                             >
                         </p>
@@ -2029,10 +2029,10 @@
 
                     <section>
                         <h3>Exercice 4</h3>
-                        <p><a href="http://cssgridgarden.com">http://cssgridgarden.com</a>/</p>
+                        <p><a href="http://cssgridgarden.com" target="_blank">http://cssgridgarden.com</a>/</p>
                         <p>
                             Si vous désirez en savoir plus (car il existe d'autres propriétés), vous pourrez les trouver
-                            détaillées ici : <a href="https://css-tricks.com/snippets/css/complete-guide-grid/"
+                            détaillées ici : <a href="https://css-tricks.com/snippets/css/complete-guide-grid/" target="_blank"
                                 >https://css-tricks.com/snippets/css/complete-guide-grid/</a
                             >
                         </p>
@@ -2048,7 +2048,7 @@
                         </p>
                         <p>
                             Pour aller plus loin : une page faite intégralement sans JS basée sur Grid : <a
-                                href="http://www.hi.agency/deck/#p1"
+                                href="http://www.hi.agency/deck/#p1" target="_blank"
                                 >http://www.hi.agency/deck/#p1</a
                             >
                         </p>
@@ -2086,9 +2086,9 @@
                             <tr>
                                 <td>em</td>
                                 <td>
-                                    1em correspond à la taille de police actuelle. 2em signifie 2 ois la taille de la
+                                    1em correspond à la taille de police actuelle. 2em signifie 2 fois la taille de la
                                     police actuelle. Si un élément a une taille de police de 12px, 2em vaudra 24px.
-                                    l'utité est d'adaper le contenu à la taille de police utilisée par le lecteur, mais
+                                    l'utilité est d'adaper le contenu à la taille de police utilisée par le lecteur, mais
                                     cela signifie aussi qu'il s'agit d'une unité inconsistante dont la valeur dépendra
                                     de la taille de police de l'endroit de la page où on l'utilise.
                                 </td>
@@ -2286,6 +2286,14 @@
                             Par exemple, si on a width qui vaut 90% et margin qui vaut 100px, passé une certaine taille
                             d'écran, l'élément et ses marges dépassent 100% de la taille disponible.
                         </p>
+                    </section>
+
+                    <section>
+                        <h3>Calc</h3>
+                        <p>
+                            Si on souhaite avoir des marges de 100% et que l'élément occupe la taille restante, il
+                            suffit de faire :
+                        </p>
                         <pre>
                             <code class="css" data-trim>
                                 <script type="text/template">
@@ -2295,14 +2303,6 @@
                                 </script>
                             </code>
                         </pre>
-                    </section>
-
-                    <section>
-                        <h3>Calc</h3>
-                        <p>
-                            Si on souhaite avoir des marges de 100% et que l'élément occupe la taille restante, il
-                            suffit de faire :
-                        </p>
                         <p>
                             Il est possible d'effectuer autant d'opérations que souhaité. Les opérateurs +, -, *
                             existent, de même que / (mais de toute évidence, on ne peut diviser que par un nombre, pas
@@ -2349,7 +2349,7 @@
                         <h3>Articles</h3>
                         <p>
                             CSS BIO :
-                            <a href="https://css-tricks.com/combining-the-powers-of-sem-and-bio-for-improving-css/"
+                            <a href="https://css-tricks.com/combining-the-powers-of-sem-and-bio-for-improving-css/" target="_blank"
                                 >https://css-tricks.com/combining-the-powers-of-sem-and-bio-for-improving-css/</a
                             >
                         </p>
@@ -2360,25 +2360,25 @@
                         <p>Voici quelques liens pour les gens intéressés par les sujets abordés :</p>
                         <p>
                             Une des meilleures formations en ligne : <a
-                                href="http://iamvdo.me/blog/ce-que-vous-avez-toujours-voulu-savoir-sur-css"
+                                href="http://iamvdo.me/blog/ce-que-vous-avez-toujours-voulu-savoir-sur-css" target="_blank"
                                 >http://iamvdo.me/blog/ce-que-vous-avez-toujours-voulu-savoir-sur-css</a
                             >
                         </p>
                         <p>
                             Comment on faisait avant CSS (et pourquoi CSS, c'est pas si mal) : <a
-                                href="https://developer.telerik.com/topics/web-development/love-letter-css/"
+                                href="https://developer.telerik.com/topics/web-development/love-letter-css/" target="_blank"
                                 >https://developer.telerik.com/topics/web-development/love-letter-css/</a
                             >
                         </p>
                         <p>
                             CSS et JS (et les petits qu'ils ont fait ensemble) : <a
-                                href="https://medium.com/seek-blog/a-unified-styling-language-d0c208de2660"
+                                href="https://medium.com/seek-blog/a-unified-styling-language-d0c208de2660" target="_blank"
                                 >https://medium.com/seek-blog/a-unified-styling-language-d0c208de2660</a
                             >
                         </p>
                         <p>
                             Grid, c'est bien, c'est Slack qui le dit : <a
-                                href="https://slack.engineering/rebuilding-slack-com-b124c405c193"
+                                href="https://slack.engineering/rebuilding-slack-com-b124c405c193" target="_blank"
                                 >https://slack.engineering/rebuilding-slack-com-b124c405c193</a
                             >
                         </p>
@@ -2390,7 +2390,7 @@
                             Les polices, c'est plus compliqué qu'il n'y parait (où vous apprendrez précisément ce qu'est
                             le x-height et qu'aligner des polices différentes en maintenant une taille unique de ligne,
                             c'est pas marrant) : <a
-                                href="https://iamvdo.me/blog/css-avance-metriques-des-fontes-line-height-et-vertical-align"
+                                href="https://iamvdo.me/blog/css-avance-metriques-des-fontes-line-height-et-vertical-align" target="_blank"
                                 >https://iamvdo.me/blog/css-avance-metriques-des-fontes-line-height-et-vertical-align</a
                             >
                         </p>
@@ -2399,7 +2399,7 @@
                             délimitation (genre <600px, on a un premier style, > 600px, un autre, lors du
                             redimensionnement il y aura un saut du premier style au second). Quelqu'un a décidé de voir
                             comment faire disparaitre ce saut pour les tailles de police. <a
-                                href="https://www.smashingmagazine.com/2017/05/fluid-responsive-typography-css-poly-fluid-sizing/"
+                                href="https://www.smashingmagazine.com/2017/05/fluid-responsive-typography-css-poly-fluid-sizing/" target="_blank"
                                 >https://www.smashingmagazine.com/2017/05/fluid-responsive-typography-css-poly-fluid-sizing/</a
                             >
                         </p>
@@ -2409,18 +2409,18 @@
                         <h3>Articles</h3>
                         <p>
                             Les contextes d'empilement (avouez-le, ça vous fait rêver) : <a
-                                href="https://iamvdo.me/blog/comprendre-z-index-et-les-contextes-dempilement"
+                                href="https://iamvdo.me/blog/comprendre-z-index-et-les-contextes-dempilement" target="_blank"
                                 >https://iamvdo.me/blog/comprendre-z-index-et-les-contextes-dempilement</a
                             >
                         </p>
                         <p>
                             Des petits détails pas inintéressants : <a
-                                href="https://medium.com/@devdevcharlie/things-nobody-ever-taught-me-about-css-5d16be8d5d0e"
+                                href="https://medium.com/@devdevcharlie/things-nobody-ever-taught-me-about-css-5d16be8d5d0e" target="_blank"
                                 >https://medium.com/@devdevcharlie/things-nobody-ever-taught-me-about-css-5d16be8d5d0e</a
                             >
                         </p>
                         <p>
-                            Une petite présentation de Houdini : <a href="https://slides.iamvdo.me/waq19/fr/#/"
+                            Une petite présentation de Houdini : <a href="https://slides.iamvdo.me/waq19/fr/#/" target="_blank"
                                 >https://slides.iamvdo.me/waq19/fr/#/</a
                             >
                         </p>
@@ -2429,13 +2429,13 @@
                     <section>
                         <h3>Articles</h3>
                         <p>
-                            Un générateur de gradients linéaires : <a href="http://ourownthing.co.uk/gradpad.html"
+                            Un générateur de gradients linéaires : <a href="http://ourownthing.co.uk/gradpad.html" target="_blank"
                                 >http://ourownthing.co.uk/gradpad.html</a
                             > (cliquez sur "Get CSS for this Gradient" pour récupérer le code)
                         </p>
                         <p>
                             Un site qui calcule toutes les spécificités de vos sélecteurs et en affiche un joli graphe
-                            : <a href="https://isellsoap.github.io/specificity-visualizer/"
+                            : <a href="https://isellsoap.github.io/specificity-visualizer/" target="_blank"
                                 >https://isellsoap.github.io/specificity-visualizer/</a
                             > (indice: si vous avez du rouge ou des sélecteurs à complexité très haute, ce n'est pas
                             bien)
@@ -2445,7 +2445,7 @@
                             ou "-right" pour les adapter au sens de lecture (qui peut changer selon la langue, ce qui
                             peut casser le layout de votre site). Cela consiste à utiliser des propriétés "-start" ou
                             "-end" à la place, ce qui n'est, il faut le dire, pas con. <a
-                                href="https://drafts.csswg.org/css-logical/"
+                                href="https://drafts.csswg.org/css-logical/" target="_blank"
                                 >https://drafts.csswg.org/css-logical/</a
                             >
                         </p>


### PR DESCRIPTION
Corrections of typos 
Add Target Blank to link to open in new tab